### PR TITLE
twitter/gist連携とプライベート投稿のサポート

### DIFF
--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -55,9 +55,9 @@ endfunction
 
 function! s:api.post_item(params)
   let params = deepcopy(a:params)
-  let params['tweet'] = exists("g:qiita_vim_twitter") ? g:qiita_vim_twitter : v:false
-  let params['gist'] = exists("g:qiita_vim_gist") ? g:qiita_vim_gist : v:false
-  let params['private'] = exists("g:qiita_vim_private") ? g:qiita_vim_private : v:false
+  let params['tweet'] = get(g:, 'qiita_vim_twitter', v:false)
+  let params['gist'] = get(g:, 'qiita_vim_gist', v:false)
+  let params['private'] = get(g:, 'qiita_vim_private', v:false)
   if has_key(params, 'id')
     let res = json_decode(webapi#http#post(printf('https://qiita.com/api/v2/items/%s', params['id']), json_encode(params),
                                                 \ {'Content-Type': 'application/json', 'Authorization': 'Bearer ' . self.token}).content)
@@ -172,7 +172,7 @@ function! s:item.update()
                \ 'id': self['id'],
                \ 'title': self['title'],
                \ 'tags': self['tags'],
-               \ 'private': exists("g:qiita_vim_private") ? g:qiita_vim_private : v:false,
+               \ 'private': get(g:, 'qiita_vim_private', v:false),
                \}
   let res = json_decode(webapi#http#post(printf('https://qiita.com/api/v2/items/%s', self['id']), json_encode(content), {'Content-Type': 'application/json', 'X-HTTP-Method-Override': 'PATCH', 'Authorization': 'Bearer ' . self.token}).content)
   if has_key(res, 'type')

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -55,6 +55,9 @@ endfunction
 
 function! s:api.post_item(params)
   let params = deepcopy(a:params)
+  let params['tweet'] = exists("g:qiita_vim_twitter") ? g:qiita_vim_twitter : v:false
+  let params['gist'] = exists("g:qiita_vim_gist") ? g:qiita_vim_gist : v:false
+  let params['private'] = exists("g:qiita_vim_private") ? g:qiita_vim_private : v:false
   if has_key(params, 'id')
     let res = json_decode(webapi#http#post(printf('https://qiita.com/api/v2/items/%s', params['id']), json_encode(params),
                                                 \ {'Content-Type': 'application/json', 'Authorization': 'Bearer ' . self.token}).content)
@@ -169,7 +172,7 @@ function! s:item.update()
                \ 'id': self['id'],
                \ 'title': self['title'],
                \ 'tags': self['tags'],
-               \ 'private': v:false,
+               \ 'private': exists("g:qiita_vim_private") ? g:qiita_vim_private : v:false,
                \}
   let res = json_decode(webapi#http#post(printf('https://qiita.com/api/v2/items/%s', self['id']), json_encode(content), {'Content-Type': 'application/json', 'X-HTTP-Method-Override': 'PATCH', 'Authorization': 'Bearer ' . self.token}).content)
   if has_key(res, 'type')
@@ -285,7 +288,6 @@ function! s:write_item(api, id, title, content)
       \ 'title': a:title,
       \ 'body': a:content,
       \ 'tags': [{'name': tag}],
-      \ 'private': v:false,
       \})
     catch
       redraw

--- a/doc/qiita.txt
+++ b/doc/qiita.txt
@@ -15,6 +15,7 @@ CONTENTS                                                        *qiita-contents*
 INTRODUCTION           |qiita-introduction|
 INTERFACE              |qiita-interface|
 COMMAND                |qiita-command|
+VARIABLE               |qiita-variable|
 LINKS                  |qiita-links|
 
 ==============================================================================
@@ -117,6 +118,27 @@ COMMMAND                                                         *qiita-command*
 
     :Qiita -l cho45
 <
+==============================================================================
+VARIABLE                                                        *qiita-variable*
+
+All variables are set to false by default
+
+g:qiita_vim_twitter                           *g:qiita_vim_twitter*
+    true if you want to post to twitter.
+>
+    let g:qiita_vim_twitter = v:true
+<
+g:qiita_vim_gist                              *g:qiita_vim_gist*
+    true if you want to post to twitter.
+>
+    let g:qiita_vim_gist = v:true
+<
+g:qiita_vim_private                           *g:qiita_vim_private*
+    true if you want to post privately
+>
+    let g:qiita_vim_private = v:true
+<
+
 ==============================================================================
 LINKS                                                              *qiita-links*
 


### PR DESCRIPTION
記事投稿時に、twitter/gist連携とプライベート投稿ができるようにしました。
`vimrc`に各変数を設定しておくことで有効にできます。
デフォルトでは全てfalse(twitter/gistに投稿せず、パブリック投稿)です。

* g:qiita_vim_twitter  -- `true`にすると、新規記事投稿時にtwitterに投稿するようになります。
* g:qiita_vim_gist     -- `true`にすると、コードスニペットをgistに投げるようになります。
* g:qiita_vim_private  -- `true`にすると、プライベート投稿ができるようになります。