### PR TITLE
feature: tag付対応

### DIFF
--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -262,13 +262,18 @@ function! Gettag(tags_string)
   if ! len(a:tags_string)
     return []
   else
+    let bracket_s = len(substitute(a:tags_string, '[^\[]', '', 'g'))
+    let brachet_e = len(substitute(a:tags_string, '[^\]]', '', 'g'))
+    if bracket_s != brachet_e
+      throw "you can't use [] in tag"
+    endif
     let tags_string = deepcopy(a:tags_string)
     let tags_string = substitute(tags_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', 'g')
     let tags_string = substitute(tags_string, '\[[^\]]*\]\zs[^\[]*\ze', '', 'g')
 
     " generate expr
     let expr = ""
-    for i in range(len(substitute(tags_string, '[^\[]', '', 'g')))
+    for i in range(bracket_s)
       let expr = expr . '\[\([^\[]*\)\]'
     endfor
 

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -263,14 +263,10 @@ function! s:gettags(tags_string)
     return []
   endif
 
-  let tags_list = split(a:tags_string, '\s')
+  let tags_list = split(a:tags_string, '\s+')
   let ret = []
   " generate tags list.
   for id in tags_list
-    if id == ''
-      continue
-    endif
-
     if match(id, ":") > 0
       call add(ret, {'name': matchstr(id, "\\zs[^:]*\\ze:"),
                    \ 'versions': [matchstr(id, ":\\zs.*\\ze")]})

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -475,7 +475,7 @@ function! qiita#Qiita(...)
     if editpost
       let title = getline(1)
       let tags = s:gettags(getline(2))
-      let content = join(getline(3, line('$')), "\n")
+      let content = join(getline(3, '$'), "\n")
       call s:write_item(api, id, title, tags, content)
     elseif deletepost
       call s:delete_item(api, id)
@@ -484,7 +484,7 @@ function! qiita#Qiita(...)
     else
       let title = getline(1)
       let tags = s:gettags(getline(2))
-      let content = join(getline(3, line('$')), "\n")
+      let content = join(getline(3, '$'), "\n")
       call s:write_item(api, '', title, tags, content)
     endif
   endif

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -268,8 +268,8 @@ function! Gettag(tags_string)
 
     " generate expr
     let expr = ""
-      expr += '\[\([^\[]*\)\]'
     for i in range(len(substitute(tags_string, '[^\[]', '', 'g')))
+      let expr = expr . '\[\([^\[]*\)\]'
     endfor
 
     let tags_list = matchlist(tags_string, expr)

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -263,8 +263,8 @@ function! Gettag(tags_string)
     return []
   else
     let tags_string = deepcopy(a:tags_string)
-    let tags_string = substitute(tags_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', '')
-    let tags_string = substitute(tags_string, '\[[^\]]*\]\zs[^\[]*\ze', '', '')
+    let tags_string = substitute(tags_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', 'g')
+    let tags_string = substitute(tags_string, '\[[^\]]*\]\zs[^\[]*\ze', '', 'g')
 
     " generate expr
     let expr = ""

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -262,23 +262,16 @@ function! s:gettags(tags_string)
   if ! len(a:tags_string)
     return []
   else
-    let bracket_s = len(substitute(a:tags_string, '[^\[]', '', 'g'))
-    let brachet_e = len(substitute(a:tags_string, '[^\]]', '', 'g'))
-    if bracket_s != brachet_e
-      throw "you can't use [] in tag"
-    endif
-    let tags_string = deepcopy(a:tags_string)
-    let tags_string = substitute(tags_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', 'g')
-    let tags_string = substitute(tags_string, '\[[^\]]*\]\zs[^\[]*\ze', '', 'g')
-
-    " generate expr
-    let expr = ""
-    for i in range(bracket_s)
-      let expr = expr . '\[\([^\[]*\)\]'
+    let tags_list = split(a:tags_string, ' ')
+    let ret = []
+    " generate tags list.
+    for id in tags_list
+      if id != ''
+        call add(ret, {'name': id})
+      endif
     endfor
 
-    let tags_list = matchlist(tags_string, expr)
-    return tags_list[1:]
+    return ret
 endfunction
 
 

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -273,7 +273,7 @@ function! Gettag(tags_string)
     endfor
 
     let tags_list = matchlist(tags_string, expr)
-    return tags_list
+    return tags_list[1:]
 endfunction
 
 

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -258,7 +258,7 @@ function! s:fix_tags(tags)
 endfunction
 
 
-function! Gettag(tags_string)
+function! s:gettags(tags_string)
   if ! len(a:tags_string)
     return []
   else

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -353,7 +353,16 @@ function! s:open_item(api, id)
   redraw
 
   let item = a:api.item(a:id)
-  call setline(1, [webapi#html#decodeEntityReference(item.title)]+split(item.body, "\n"))
+  let l:tag_line = ''
+  for tag in item.tags
+    if tag['versions'] == []
+      let tag_line.=tag['name'] . ' '
+    else
+      let tag_line.=tag['name'] . ':' . tag['versions'][0] . ' '
+    endif
+    " [{'name': '', 'versions': ''}, ...]
+  endfor
+  call setline(1, [webapi#html#decodeEntityReference(item.title), tag_line]+split(item.body, "\n"))
   setlocal buftype=acwrite bufhidden=delete noswapfile
   setlocal nomodified
   setlocal ft=markdown

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -263,7 +263,7 @@ function! s:gettags(tags_string)
     return []
   endif
 
-  let tags_list = split(a:tags_string, ' ')
+  let tags_list = split(a:tags_string, '\s')
   let ret = []
   " generate tags list.
   for id in tags_list

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -257,6 +257,26 @@ function! s:fix_tags(tags)
   endfor
 endfunction
 
+
+function! Gettag(tag_string)
+  if ! len(a:tag_string)
+    return []
+  else
+    let tag_string = deepcopy(a:tag_string)
+    tag_string = substitute(tag_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', '') " remove non-tag strings
+    tag_string = substitute(tag_string, '\[[^\]]*\]\zs[^\[]*\ze', '', '')   "
+
+    " generate expr
+    let expr = ""
+    for i in len(substitute(tag_string, '[^\[]', '', 'g'))
+      expr += '\[\([^\[]*\)\]'
+    endfor
+
+    let tag_list = matchlist(tag_string, expr)
+    return tag_list
+endfunction
+
+
 function! s:write_item(api, id, title, content)
   if len(a:id)
     redraw | echon 'Updating item... '

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -258,22 +258,22 @@ function! s:fix_tags(tags)
 endfunction
 
 
-function! Gettag(tag_string)
-  if ! len(a:tag_string)
+function! Gettag(tags_string)
+  if ! len(a:tags_string)
     return []
   else
-    let tag_string = deepcopy(a:tag_string)
-    tag_string = substitute(tag_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', '') " remove non-tag strings
-    tag_string = substitute(tag_string, '\[[^\]]*\]\zs[^\[]*\ze', '', '')   "
+    let tags_string = deepcopy(a:tags_string)
+    let tags_string = substitute(tags_string, '\zs[^\[\]]*\ze\[[^\]]*\]', '', '')
+    let tags_string = substitute(tags_string, '\[[^\]]*\]\zs[^\[]*\ze', '', '')
 
     " generate expr
     let expr = ""
-    for i in len(substitute(tag_string, '[^\[]', '', 'g'))
       expr += '\[\([^\[]*\)\]'
+    for i in range(len(substitute(tags_string, '[^\[]', '', 'g')))
     endfor
 
-    let tag_list = matchlist(tag_string, expr)
-    return tag_list
+    let tags_list = matchlist(tags_string, expr)
+    return tags_list
 endfunction
 
 

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -259,26 +259,27 @@ endfunction
 
 
 function! s:gettags(tags_string)
-  if ! len(a:tags_string)
+  if len(a:tags_string) == 0
     return []
-  else
-    let tags_list = split(a:tags_string, ' ')
-    let ret = []
-    " generate tags list.
-    for id in tags_list
-      if id == ''
-        continue
-      endif
+  endif
 
-      if match(id, ":") > 0
-        call add(ret, {'name': matchstr(id, "\\zs[^:]*\\ze:"),
-                     \ 'versions': [matchstr(id, ":\\zs.*\\ze")]})
-      else
-        call add(ret, {'name': id})
-      endif
-    endfor
+  let tags_list = split(a:tags_string, ' ')
+  let ret = []
+  " generate tags list.
+  for id in tags_list
+    if id == ''
+      continue
+    endif
 
-    return ret
+    if match(id, ":") > 0
+      call add(ret, {'name': matchstr(id, "\\zs[^:]*\\ze:"),
+                   \ 'versions': [matchstr(id, ":\\zs.*\\ze")]})
+    else
+      call add(ret, {'name': id})
+    endif
+  endfor
+
+  return ret
 endfunction
 
 

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -266,7 +266,14 @@ function! s:gettags(tags_string)
     let ret = []
     " generate tags list.
     for id in tags_list
-      if id != ''
+      if id == ''
+        continue
+      endif
+
+      if match(id, ":") > 0
+        call add(ret, {'name': matchstr(id, "\\zs[^:]*\\ze:"),
+                     \ 'versions': [matchstr(id, ":\\zs.*\\ze")]})
+      else
         call add(ret, {'name': id})
       endif
     endfor

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -461,16 +461,18 @@ function! qiita#Qiita(...)
   else
     if editpost
       let title = getline(1)
-      let content = join(getline(2, line('$')), "\n")
-      call s:write_item(api, id, title, content)
+      let tags = s:gettags(getline(2))
+      let content = join(getline(3, line('$')), "\n")
+      call s:write_item(api, id, title, tags, content)
     elseif deletepost
       call s:delete_item(api, id)
     elseif len(id) > 0
       call s:open_item(api, id)
     else
       let title = getline(1)
-      let content = join(getline(2, line('$')), "\n")
-      call s:write_item(api, '', title, content)
+      let tags = s:gettags(getline(2))
+      let content = join(getline(3, line('$')), "\n")
+      call s:write_item(api, '', title, tags, content)
     endif
   endif
   return 1

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -275,12 +275,13 @@ function! s:gettags(tags_string)
 endfunction
 
 
-function! s:write_item(api, id, title, content)
+function! s:write_item(api, id, title, tags, content)
   if len(a:id)
     redraw | echon 'Updating item... '
     let item = a:api.item(a:id)
     let item.title = a:title
     let item.body = a:content
+    let item.tags = a:tags
     call s:fix_tags(item.tags)
     try
       call item.update()
@@ -291,18 +292,20 @@ function! s:write_item(api, id, title, content)
     endtry
   else
     redraw | echon 'Posting item... '
-    let tag = expand('%:e')
-    if len(tag) == 0
-      let tag = &ft
-    endif
-    if len(tag) == 0
-      let tag = 'text'
+    if len(a:tags) == 0
+      if len(&ft) == 0
+        let l:tags = [{'name': 'text'}]
+      else
+        let l:tags = [{'name': &ft}]
+      endif
+    else
+      let l:tags = a:tags
     endif
     try
       let item = a:api.post_item({
       \ 'title': a:title,
       \ 'body': a:content,
-      \ 'tags': [{'name': tag}],
+      \ 'tags': l:tags,
       \ 'private': v:false,
       \})
     catch


### PR DESCRIPTION
記事を書く際に、tagを指定することができるようになりました。
タグは2行目に、空白文字` `区切りで記載します。
バージョン情報がある場合は、Qiitaでのものと同じく、`<tag名>:<version>`という表記になります。

https://asciinema.org/a/211390