### PR TITLE
[bugfix]正規表現修正

### DIFF
--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -266,7 +266,7 @@ function! s:gettags(tags_string)
     return []
   endif
 
-  let tags_list = split(a:tags_string, '\s+')
+  let tags_list = split(a:tags_string, '\s\+')
   let ret = []
   " generate tags list.
   for id in tags_list


### PR DESCRIPTION
前回の「タグ対応」のコードレビューにて、`\s\+`と書かれていたところを`\s+`と書いてしまっており、`+`が正規表現として機能してくれていませんでした...
その弊害として、現状だと「先頭がバージョン情報がないタグ」だと投稿ができず、またバージョン情報があるタグだとしても「それ以降のタグは無視されてしまう」状況です。

連投してしまっており申し訳ないです...orz