### PR TITLE
既存の投稿をアップデートする際タグを消してしまうとbad_requestになるのを修正

### DIFF
--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -263,7 +263,7 @@ endfunction
 
 function! s:gettags(tags_string)
   if len(a:tags_string) == 0
-    return []
+    return [{'name':''}]
   endif
 
   let tags_list = split(a:tags_string, '\s\+')

--- a/autoload/qiita.vim
+++ b/autoload/qiita.vim
@@ -299,20 +299,12 @@ function! s:write_item(api, id, title, tags, content)
     endtry
   else
     redraw | echon 'Posting item... '
-    if len(a:tags) == 0
-      if len(&ft) == 0
-        let l:tags = [{'name': 'text'}]
-      else
-        let l:tags = [{'name': &ft}]
-      endif
-    else
-      let l:tags = a:tags
-    endif
+    call s:fix_tags(a:tags)
     try
       let item = a:api.post_item({
       \ 'title': a:title,
       \ 'body': a:content,
-      \ 'tags': l:tags,
+      \ 'tags': a:tags,
       \ 'private': v:false,
       \})
     catch


### PR DESCRIPTION
元々の問題
==========

`:Qiita -l`から投稿を取得し、タグを削除し`:w`(`:Qiita -e`)でアップロードすると、`bad_request`を返されてしまっていた

原因
=====

`fix_tags`がうまく動いていなかったことが原因でした。
本来、タグが何も指定されていなかった場合`fix_tags`内でfiletypeもしくは`text`タグが設定されるはずでしたが、アップデートの際は`fix_tags`に渡すタグのリストが空だったためfor文が回らず、修正されていませんでした。
その結果tagが空のリストとして渡され、APIにリクエストした時にエラーを吐かれていたようです。

修正部分
=======

`gettags`にて、タグが見つからなかった場合は`[{'name':''}]`を返すことにしました。
これにより、`fix_tags`で正常にタグが修正されるので、タグ指定を無くした場合でもアップデートできるようになりました。

またこれに伴い、新規投稿の際のコードも共通化しました。